### PR TITLE
Added AnimatedPadding widget support

### DIFF
--- a/example/assets/pages/animated_align.json
+++ b/example/assets/pages/animated_align.json
@@ -20,8 +20,8 @@
       "child": {
         "type": "animated_align",
         "args": {
-          "duration": 1000,
-          "alignment": "{{customAlign}}"
+          "alignment": "{{customAlign}}",
+          "duration": 1000
         },
         "child": {
           "type": "container",

--- a/example/assets/pages/animated_padding.json
+++ b/example/assets/pages/animated_padding.json
@@ -1,0 +1,49 @@
+{
+  "type": "scaffold",
+  "args": {
+    "appBar": {
+      "type": "app_bar",
+      "args": {
+        "title": {
+          "type": "text",
+          "args": {
+            "text": "AnimatedPadding"
+          }
+        }
+      }
+    },
+    "body": {
+      "type": "set_value",
+      "args": {
+        "customPadding": 1
+      },
+      "child": {
+        "type": "animated_padding",
+        "args": {
+          "duration": 1000,
+          "padding": "{{customPadding}}"
+        },
+        "child": {
+          "type": "container",
+          "args": {
+            "color": "#FF0000",
+            "height": 20,
+            "width": 20
+          }
+        }
+      }
+    },
+    "floatingActionButton": {
+      "type": "raised_button",
+      "args": {
+        "onPressed": "##set_value(customPadding, 100)##"
+      },
+      "child": {
+        "type": "text",
+        "args": {
+          "text": "Press Me!"
+        }
+      }
+    }
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -140,6 +140,7 @@ class RootPage extends StatelessWidget {
     'align',
     'animated_align',
     'animated_opacity',
+    'animated_padding',
     'aspect_ratio',
     'asset_images',
     'bank_example',

--- a/lib/json_dynamic_widget.dart
+++ b/lib/json_dynamic_widget.dart
@@ -1,6 +1,7 @@
 export 'src/builders/json_align_builder.dart';
 export 'src/builders/json_animated_align_builder.dart';
 export 'src/builders/json_animated_opacity_builder.dart';
+export 'src/builders/json_animated_padding_builder.dart';
 export 'src/builders/json_app_bar_builder.dart';
 export 'src/builders/json_aspect_ratio_builder.dart';
 export 'src/builders/json_asset_image_builder.dart';

--- a/lib/src/builders/json_animated_padding_builder.dart
+++ b/lib/src/builders/json_animated_padding_builder.dart
@@ -1,0 +1,113 @@
+import 'package:child_builder/child_builder.dart';
+import 'package:flutter/material.dart';
+import 'package:json_class/json_class.dart';
+import 'package:json_dynamic_widget/json_dynamic_widget.dart';
+import 'package:json_theme/json_theme.dart';
+
+/// Builder that can build a [JsonAnimatedPaddingBuilder] widget.
+/// See the [fromDynamic] for the format.
+class JsonAnimatedPaddingBuilder extends JsonWidgetBuilder {
+  JsonAnimatedPaddingBuilder({
+    this.curve,
+    @required this.duration,
+    this.onEnd,
+    @required this.padding,
+  })  : assert(duration != null),
+        assert(padding != null);
+
+  static const type = 'animated_padding';
+
+  final Curve curve;
+  final Duration duration;
+  final VoidCallback onEnd;
+  final EdgeInsetsGeometry padding;
+
+  /// Builds the builder from a Map-like dynamic structure.  This expects the
+  /// JSON format to be of the following structure:
+  ///
+  /// ```json
+  /// {
+  ///   "curve": <Curve>,
+  ///   "duration": <int; millis>,
+  ///   "onEnd": <VoidCallback>,
+  ///   "padding": <EdgeInsetsGeometry>,
+  /// }
+  /// ```
+  ///
+  /// As a note, the [Curve] and [VoidCallback] cannot be decoded via JSON.
+  /// Instead, the only way to bind those values to the builder is to use a
+  /// function or a variable reference via the [JsonWidgetRegistry].
+  static JsonAnimatedPaddingBuilder fromDynamic(
+    dynamic map, {
+    JsonWidgetRegistry registry,
+  }) {
+    JsonAnimatedPaddingBuilder result;
+
+    if (map != null) {
+      result = JsonAnimatedPaddingBuilder(
+        curve: map['curve'] ?? Curves.linear,
+        duration: JsonClass.parseDurationFromMillis(
+          map['duration'],
+        ),
+        onEnd: map['onEnd'],
+        padding: ThemeDecoder.decodeEdgeInsetsGeometry(
+          map['padding'],
+          validate: false,
+        ),
+      );
+    }
+
+    return result;
+  }
+
+  @override
+  Widget buildCustom({
+    ChildWidgetBuilder childBuilder,
+    BuildContext context,
+    JsonWidgetData data,
+    Key key,
+  }) {
+    assert(
+      data.children?.length == 1,
+      '[JsonAnimatedPaddingBuilder] only supports exactly one child.',
+    );
+
+    return _JsonAnimatedPadding(
+      builder: this,
+      childBuilder: childBuilder,
+      data: data,
+    );
+  }
+}
+
+class _JsonAnimatedPadding extends StatefulWidget {
+  _JsonAnimatedPadding({
+    @required this.builder,
+    @required this.childBuilder,
+    @required this.data,
+  })  : assert(builder != null),
+        assert(data != null);
+
+  final JsonAnimatedPaddingBuilder builder;
+  final ChildWidgetBuilder childBuilder;
+  final JsonWidgetData data;
+
+  @override
+  _JsonAnimatedPaddingState createState() => _JsonAnimatedPaddingState();
+}
+
+class _JsonAnimatedPaddingState extends State<_JsonAnimatedPadding> {
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedPadding(
+      curve: widget.builder.curve,
+      duration: widget.builder.duration,
+      onEnd: widget.builder.onEnd,
+      padding: widget.builder.padding,
+      child: widget.data.children[0].build(
+        childBuilder: widget.childBuilder,
+        context: context,
+      ),
+    );
+  }
+}

--- a/lib/src/components/json_widget_registry.dart
+++ b/lib/src/components/json_widget_registry.dart
@@ -102,6 +102,10 @@ class JsonWidgetRegistry {
       builder: JsonAnimatedOpacityBuilder.fromDynamic,
       schemaId: AnimatedOpacitySchema.id,
     ),
+    JsonAnimatedPaddingBuilder.type: JsonWidgetBuilderContainer(
+      builder: JsonAnimatedPaddingBuilder.fromDynamic,
+      schemaId: AnimatedPaddingSchema.id,
+    ),
     JsonAppBarBuilder.type: JsonWidgetBuilderContainer(
       builder: JsonAppBarBuilder.fromDynamic,
       schemaId: AppBarSchema.id,

--- a/lib/src/schema/all.dart
+++ b/lib/src/schema/all.dart
@@ -1,6 +1,7 @@
 export 'schemas/align_schema.dart';
 export 'schemas/animated_align_schema.dart';
 export 'schemas/animated_opacity_schema.dart';
+export 'schemas/animated_padding_schema.dart';
 export 'schemas/app_bar_schema.dart';
 export 'schemas/aspect_ratio_schema.dart';
 export 'schemas/asset_image_schema.dart';

--- a/lib/src/schema/schema_validator.dart
+++ b/lib/src/schema/schema_validator.dart
@@ -20,6 +20,7 @@ class SchemaValidator {
       cache.addSchema(AlignSchema.id, AlignSchema.schema);
       cache.addSchema(AnimatedAlignSchema.id, AnimatedAlignSchema.schema);
       cache.addSchema(AnimatedOpacitySchema.id, AnimatedOpacitySchema.schema);
+      cache.addSchema(AnimatedPaddingSchema.id, AnimatedPaddingSchema.schema);
       cache.addSchema(AppBarSchema.id, AppBarSchema.schema);
       cache.addSchema(AspectRatioSchema.id, AspectRatioSchema.schema);
       cache.addSchema(AssetImageSchema.id, AssetImageSchema.schema);

--- a/lib/src/schema/schemas/animated_padding_schema.dart
+++ b/lib/src/schema/schemas/animated_padding_schema.dart
@@ -1,0 +1,24 @@
+import 'package:json_theme/json_theme_schemas.dart';
+
+class AnimatedPaddingSchema {
+  static const id =
+      'https://peifferinnovations.com/json_dynamic_widget/schemas/animated_padding';
+
+  static final schema = {
+    r'$schema': 'http://json-schema.org/draft-06/schema#',
+    r'$id': '$id',
+    'type': 'object',
+    'title': 'AnimatedPaddingBuilder',
+    'additionalProperties': false,
+    'required': [
+      'duration',
+      'padding',
+    ],
+    'properties': {
+      'curve': SchemaHelper.stringSchema,
+      'duration': SchemaHelper.numberSchema,
+      'onEnd': SchemaHelper.stringSchema,
+      'padding': SchemaHelper.objectSchema(EdgeInsetsGeometrySchema.id),
+    },
+  };
+}

--- a/test/builders/json_animated_padding_builder_test.dart
+++ b/test/builders/json_animated_padding_builder_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:json_dynamic_widget/json_dynamic_widget.dart';
+
+void main() {
+  test('type', () {
+    const type = JsonAnimatedPaddingBuilder.type;
+
+    expect(type, 'animated_padding');
+    expect(JsonWidgetRegistry.instance.getWidgetBuilder(type) != null, true);
+    expect(
+      JsonWidgetRegistry.instance.getWidgetBuilder(type)(
+        {
+          'duration': 1000,
+          'padding': EdgeInsets.zero,
+        },
+      ) is JsonAnimatedPaddingBuilder,
+      true,
+    );
+  });
+}


### PR DESCRIPTION
## This won't merge to main yet

## Description

This PR adds the AnimatedPadding JSON widget support. Also fixes some alphabetical sorting in animated_align.json


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Code Style Guide] and followed the process outlined there for submitting PRs.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I updated `pubspec.yaml`, `build.properties`, and `ios/Podfile` with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [x] I am authorized to release this code under the MIT License and agree to do so

## UI Change

Does your PR affect any UI screens?

- [x] Yes, the relevant screens are included below.

The affected screens are `animated_padding.json` as the new widget example and `main.dart` adding the new example to the list.