### PR TITLE
Added AnimatedDefaultTextStyle widget support

### DIFF
--- a/example/assets/pages/animated_default_text_style.json
+++ b/example/assets/pages/animated_default_text_style.json
@@ -1,0 +1,52 @@
+{
+  "type": "scaffold",
+  "args": {
+    "appBar": {
+      "type": "app_bar",
+      "args": {
+        "title": {
+          "type": "text",
+          "args": {
+            "text": "AnimatedDefaultTextStyle"
+          }
+        }
+      }
+    },
+    "body": {
+      "type": "set_value",
+      "args": {
+        "customTextStyle": {
+          "color": "#FF0000"
+        }
+      },
+      "child": {
+        "type": "center",
+        "child": {
+          "type": "animated_default_text_style",
+          "args": {
+            "duration": 1500,
+            "style": "{{customTextStyle}}"
+          },
+          "child": {
+            "type": "text",
+            "args": {
+              "text": "Random text"
+            }
+          }
+        }
+      }
+    },
+    "floatingActionButton": {
+      "type": "raised_button",
+      "args": {
+        "onPressed": "##updateCustomTextStyle()##"
+      },
+      "child": {
+        "type": "text",
+        "args": {
+          "text": "Press Me!"
+        }
+      }
+    }
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -94,6 +94,14 @@ void main() async {
           var valid = Form.of(context).validate();
           registry.setValue('form_validation', valid);
         },
+    'updateCustomTextStyle': ({args, registry}) => () {
+          registry.setValue(
+            'customTextStyle',
+            TextStyle(
+              color: Colors.black,
+            ),
+          );
+        },
   });
 
   registry.setValue('customRect', Rect.largest);
@@ -130,6 +138,7 @@ class RootPage extends StatelessWidget {
   static const _pages = [
     'align',
     'animated_align',
+    'animated_default_text_style',
     'animated_opacity',
     'animated_padding',
     'aspect_ratio',

--- a/lib/json_dynamic_widget.dart
+++ b/lib/json_dynamic_widget.dart
@@ -1,5 +1,6 @@
 export 'src/builders/json_align_builder.dart';
 export 'src/builders/json_animated_align_builder.dart';
+export 'src/builders/json_animated_default_text_style_builder.dart';
 export 'src/builders/json_animated_opacity_builder.dart';
 export 'src/builders/json_animated_padding_builder.dart';
 export 'src/builders/json_app_bar_builder.dart';

--- a/lib/src/builders/json_animated_default_text_style_builder.dart
+++ b/lib/src/builders/json_animated_default_text_style_builder.dart
@@ -1,0 +1,168 @@
+import 'package:child_builder/child_builder.dart';
+import 'package:flutter/material.dart';
+import 'package:json_class/json_class.dart';
+import 'package:json_dynamic_widget/json_dynamic_widget.dart';
+import 'package:json_theme/json_theme.dart';
+
+/// Builder that can build a [JsonAnimatedDefaultTextStyleBuilder] widget.
+/// See the [fromDynamic] for the format.
+class JsonAnimatedDefaultTextStyleBuilder extends JsonWidgetBuilder {
+  JsonAnimatedDefaultTextStyleBuilder({
+    this.curve,
+    @required this.duration,
+    this.maxLines,
+    this.onEnd,
+    this.overflow,
+    this.softWrap,
+    @required this.style,
+    this.textAlign,
+    this.textHeightBehavior,
+    this.textWidthBasis,
+  })  : assert(duration != null),
+        assert(style != null);
+
+  static const type = 'animated_default_text_style';
+
+  final Curve curve;
+  final Duration duration;
+  final int maxLines;
+  final VoidCallback onEnd;
+  final TextOverflow overflow;
+  final bool softWrap;
+  final TextStyle style;
+  final TextAlign textAlign;
+  final TextHeightBehavior textHeightBehavior;
+  final TextWidthBasis textWidthBasis;
+
+  /// Builds the builder from a Map-like dynamic structure.  This expects the
+  /// JSON format to be of the following structure:
+  ///
+  /// ```json
+  /// {
+  ///   "curve": <Curve>,
+  ///   "duration": <int; millis>,
+  ///   "maxLines": <int>,
+  ///   "onEnd": <VoidCallback>,
+  ///   "overflow": <TextOverflow>
+  ///   "softWrap": <bool>,
+  ///   "style": <TextStyle>,
+  ///   "textAlign": <TextAlign>,
+  ///   "textHeightBehavior": <TextHeightBehavior>,
+  ///   "textWidthBasis": <TextWidthBasis>,
+  /// }
+  /// ```
+  ///
+  /// As a note, the [Curve] and [VoidCallback] cannot be decoded via JSON.
+  /// Instead, the only way to bind those values to the builder is to use a
+  /// function or a variable reference via the [JsonWidgetRegistry].
+  ///
+  ///  See also:
+  ///  * [ThemeDecoder.decodeTextOverflow]
+  ///  * [ThemeDecoder.decodeTextStyle]
+  ///  * [ThemeDecoder.decodeTextAlign]
+  ///  * [ThemeDecoder.decodeTextHeightBehavior]
+  ///  * [ThemeDecoder.decodeTextWidthBasis]
+  static JsonAnimatedDefaultTextStyleBuilder fromDynamic(
+    dynamic map, {
+    JsonWidgetRegistry registry,
+  }) {
+    JsonAnimatedDefaultTextStyleBuilder result;
+
+    if (map != null) {
+      result = JsonAnimatedDefaultTextStyleBuilder(
+        curve: map['curve'] ?? Curves.linear,
+        duration: JsonClass.parseDurationFromMillis(
+          map['duration'],
+        ),
+        maxLines: JsonClass.parseInt(map['maxLines']),
+        onEnd: map['onEnd'],
+        overflow: ThemeDecoder.decodeTextOverflow(
+              map['overflow'],
+              validate: false,
+            ) ??
+            TextOverflow.clip,
+        softWrap: map['software'] == null
+            ? true
+            : JsonClass.parseBool(map['softWrap']),
+        style: ThemeDecoder.decodeTextStyle(
+          map['style'],
+          validate: false,
+        ),
+        textAlign: ThemeDecoder.decodeTextAlign(
+          map['textAlign'],
+          validate: false,
+        ),
+        textHeightBehavior: ThemeDecoder.decodeTextHeightBehavior(
+          map['textHeightBehavior'],
+          validate: false,
+        ),
+        textWidthBasis: ThemeDecoder.decodeTextWidthBasis(
+              map['textWidthBasis'],
+              validate: false,
+            ) ??
+            TextWidthBasis.parent,
+      );
+    }
+
+    return result;
+  }
+
+  @override
+  Widget buildCustom({
+    ChildWidgetBuilder childBuilder,
+    BuildContext context,
+    JsonWidgetData data,
+    Key key,
+  }) {
+    assert(
+      data.children?.length == 1,
+      '[JsonAnimatedDefaultTextStyleBuilder] only supports exactly one child.',
+    );
+
+    return _JsonAnimatedDefaultTextStyle(
+      builder: this,
+      childBuilder: childBuilder,
+      data: data,
+    );
+  }
+}
+
+class _JsonAnimatedDefaultTextStyle extends StatefulWidget {
+  _JsonAnimatedDefaultTextStyle({
+    @required this.builder,
+    @required this.childBuilder,
+    @required this.data,
+  })  : assert(builder != null),
+        assert(data != null);
+
+  final JsonAnimatedDefaultTextStyleBuilder builder;
+  final ChildWidgetBuilder childBuilder;
+  final JsonWidgetData data;
+
+  @override
+  _JsonAnimatedDefaultTextStyleState createState() =>
+      _JsonAnimatedDefaultTextStyleState();
+}
+
+class _JsonAnimatedDefaultTextStyleState
+    extends State<_JsonAnimatedDefaultTextStyle> {
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedDefaultTextStyle(
+      curve: widget.builder.curve,
+      duration: widget.builder.duration,
+      maxLines: widget.builder.maxLines,
+      onEnd: widget.builder.onEnd,
+      overflow: widget.builder.overflow,
+      softWrap: widget.builder.softWrap,
+      style: widget.builder.style,
+      textAlign: widget.builder.textAlign,
+      textHeightBehavior: widget.builder.textHeightBehavior,
+      textWidthBasis: widget.builder.textWidthBasis,
+      child: widget.data.children[0].build(
+        childBuilder: widget.childBuilder,
+        context: context,
+      ),
+    );
+  }
+}

--- a/lib/src/components/json_widget_registry.dart
+++ b/lib/src/components/json_widget_registry.dart
@@ -98,6 +98,10 @@ class JsonWidgetRegistry {
       builder: JsonAnimatedAlignBuilder.fromDynamic,
       schemaId: AnimatedAlignSchema.id,
     ),
+    JsonAnimatedDefaultTextStyleBuilder.type: JsonWidgetBuilderContainer(
+      builder: JsonAnimatedDefaultTextStyleBuilder.fromDynamic,
+      schemaId: AnimatedDefaultTextStyleSchema.id,
+    ),
     JsonAnimatedOpacityBuilder.type: JsonWidgetBuilderContainer(
       builder: JsonAnimatedOpacityBuilder.fromDynamic,
       schemaId: AnimatedOpacitySchema.id,
@@ -599,7 +603,6 @@ class JsonWidgetRegistry {
     dynamic value,
   ) {
     assert(key?.isNotEmpty == true);
-
     if (value == null) {
       removeValue(key);
     } else {

--- a/lib/src/schema/all.dart
+++ b/lib/src/schema/all.dart
@@ -1,5 +1,6 @@
 export 'schemas/align_schema.dart';
 export 'schemas/animated_align_schema.dart';
+export 'schemas/animated_default_text_style_schema.dart';
 export 'schemas/animated_opacity_schema.dart';
 export 'schemas/animated_padding_schema.dart';
 export 'schemas/app_bar_schema.dart';

--- a/lib/src/schema/schema_validator.dart
+++ b/lib/src/schema/schema_validator.dart
@@ -19,6 +19,8 @@ class SchemaValidator {
 
       cache.addSchema(AlignSchema.id, AlignSchema.schema);
       cache.addSchema(AnimatedAlignSchema.id, AnimatedAlignSchema.schema);
+      cache.addSchema(AnimatedDefaultTextStyleSchema.id,
+          AnimatedDefaultTextStyleSchema.schema);
       cache.addSchema(AnimatedOpacitySchema.id, AnimatedOpacitySchema.schema);
       cache.addSchema(AnimatedPaddingSchema.id, AnimatedPaddingSchema.schema);
       cache.addSchema(AppBarSchema.id, AppBarSchema.schema);

--- a/lib/src/schema/schemas/animated_default_text_style_schema.dart
+++ b/lib/src/schema/schemas/animated_default_text_style_schema.dart
@@ -1,0 +1,31 @@
+import 'package:json_theme/json_theme_schemas.dart';
+
+class AnimatedDefaultTextStyleSchema {
+  static const id =
+      'https://peifferinnovations.com/json_dynamic_widget/schemas/animated_default_text_style';
+
+  static final schema = {
+    r'$schema': 'http://json-schema.org/draft-06/schema#',
+    r'$id': '$id',
+    'type': 'object',
+    'title': 'AnimatedDefaultTextStyleBuilder',
+    'additionalProperties': false,
+    'required': [
+      'duration',
+      'style',
+    ],
+    'properties': {
+      'curve': SchemaHelper.stringSchema,
+      'duration': SchemaHelper.numberSchema,
+      'maxLines': SchemaHelper.numberSchema,
+      'onEnd': SchemaHelper.stringSchema,
+      'overflow': SchemaHelper.objectSchema(TextOverflowSchema.id),
+      'softWrap': SchemaHelper.boolSchema,
+      'style': SchemaHelper.objectSchema(TextStyleSchema.id),
+      'textAlign': SchemaHelper.objectSchema(TextAlignSchema.id),
+      'textHeightBehavior':
+          SchemaHelper.objectSchema(TextHeightBehaviorSchema.id),
+      'textWidthBasis': SchemaHelper.objectSchema(TextWidthBasisSchema.id),
+    },
+  };
+}

--- a/test/builders/json_animated_default_text_style_builder_test.dart
+++ b/test/builders/json_animated_default_text_style_builder_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:json_dynamic_widget/json_dynamic_widget.dart';
+
+void main() {
+  test('type', () {
+    const type = JsonAnimatedDefaultTextStyleBuilder.type;
+
+    expect(type, 'animated_default_text_style');
+    expect(JsonWidgetRegistry.instance.getWidgetBuilder(type) != null, true);
+    expect(
+      JsonWidgetRegistry.instance.getWidgetBuilder(type)(
+        {
+          'duration': 1000,
+          'style': {
+            'color': '#FFF',
+          }
+        },
+      ) is JsonAnimatedDefaultTextStyleBuilder,
+      true,
+    );
+  });
+}


### PR DESCRIPTION
## This won't merge to main yet

## Description

This PR adds the AnimatedDefaultTextStyle JSON widget support.


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Code Style Guide] and followed the process outlined there for submitting PRs.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I updated `pubspec.yaml`, `build.properties`, and `ios/Podfile` with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [x] I am authorized to release this code under the MIT License and agree to do so


## UI Change

Does your PR affect any UI screens?

- [x] Yes, the relevant screens are included below.

The affected screens are `animated_default_text_style.json` as the new widget example and `main.dart` adding the new example to the list.
