### PR TITLE
Added AnimatedTheme widget support

### DIFF
--- a/example/assets/pages/animated_physical_model.json
+++ b/example/assets/pages/animated_physical_model.json
@@ -37,10 +37,7 @@
               "type": "animated_physical_model",
               "args": {
                 "animateColor": true,
-                "borderRadius": {
-                  "type": "circular",
-                  "radius": 10
-                },
+                "borderRadius": "{{customBorderRadius}}",
                 "color": "{{customColor}}",
                 "duration": 1000,
                 "elevation": "{{customElevation}}",

--- a/example/assets/pages/animated_positioned_directional.json
+++ b/example/assets/pages/animated_positioned_directional.json
@@ -7,7 +7,7 @@
         "title": {
           "type": "text",
           "args": {
-            "text": "AnimatedPositioned"
+            "text": "AnimatedPositionedDirectional"
           }
         }
       }

--- a/example/assets/pages/animated_theme.json
+++ b/example/assets/pages/animated_theme.json
@@ -1,0 +1,51 @@
+{
+  "type": "set_value",
+  "args": {
+    "customColor": "#FF0000"
+  },
+  "child": {
+    "type": "set_value",
+    "args": {
+      "customThemeData": {
+        "appBarTheme": {
+          "color": "{{customColor}}"
+        }
+      }
+    },
+    "child": {
+      "type": "animated_theme",
+      "args": {
+        "data": "{{customThemeData}}",
+        "duration": 1000
+      },
+      "child": {
+        "type": "scaffold",
+        "args": {
+          "appBar": {
+            "type": "app_bar",
+            "args": {
+              "title": {
+                "type": "text",
+                "args": {
+                  "text": "AnimatedTheme"
+                }
+              }
+            }
+          },
+          "floatingActionButton": {
+            "type": "raised_button",
+            "args": {
+              "onPressed": "##set_value(customColor, #0000FF)##"
+            },
+            "child": {
+              "type": "text",
+              "args": {
+                "text": "Press Me!"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -144,6 +144,7 @@ class RootPage extends StatelessWidget {
     'animated_physical_model',
     'animated_positioned',
     'animated_positioned_directional',
+    'animated_theme',
     'aspect_ratio',
     'asset_images',
     'bank_example',

--- a/lib/json_dynamic_widget.dart
+++ b/lib/json_dynamic_widget.dart
@@ -6,6 +6,7 @@ export 'src/builders/json_animated_padding_builder.dart';
 export 'src/builders/json_animated_physical_model_builder.dart';
 export 'src/builders/json_animated_positioned_builder.dart';
 export 'src/builders/json_animated_positioned_directional_builder.dart';
+export 'src/builders/json_animated_theme_builder.dart';
 export 'src/builders/json_app_bar_builder.dart';
 export 'src/builders/json_aspect_ratio_builder.dart';
 export 'src/builders/json_asset_image_builder.dart';

--- a/lib/src/builders/json_animated_theme_builder.dart
+++ b/lib/src/builders/json_animated_theme_builder.dart
@@ -1,0 +1,121 @@
+import 'package:child_builder/child_builder.dart';
+import 'package:flutter/material.dart';
+import 'package:json_class/json_class.dart';
+import 'package:json_dynamic_widget/json_dynamic_widget.dart';
+import 'package:json_theme/json_theme.dart';
+
+/// Builder that can build an [AnimatedTheme] widget.
+/// See the [fromDynamic] for the format.
+class JsonAnimatedThemeBuilder extends JsonWidgetBuilder {
+  JsonAnimatedThemeBuilder({
+    this.curve,
+    @required this.data,
+    this.duration,
+    this.isMaterialAppTheme,
+    this.onEnd,
+  }) : assert(data != null);
+
+  static const type = 'animated_theme';
+
+  final Curve curve;
+  final ThemeData data;
+  final Duration duration;
+  final bool isMaterialAppTheme;
+  final VoidCallback onEnd;
+
+  /// Builds the builder from a Map-like dynamic structure.  This expects the
+  /// JSON format to be of the following structure:
+  ///
+  /// ```json
+  /// {
+  ///   "curve": <Curve>,
+  ///   "data": <ThemeData>,
+  ///   "duration": <int; millis>,
+  ///   "isMaterialAppTheme": <bool>,
+  ///   "onEnd": <VoidCallback>,
+  /// }
+  /// ```
+  ///
+  /// As a note, the [Curve] and [VoidCallback] cannot be decoded via JSON.
+  /// Instead, the only way to bind those values to the builder is to use a
+  /// function or a variable reference via the [JsonWidgetRegistry].
+  static JsonAnimatedThemeBuilder fromDynamic(
+    dynamic map, {
+    JsonWidgetRegistry registry,
+  }) {
+    JsonAnimatedThemeBuilder result;
+
+    if (map != null) {
+      result = JsonAnimatedThemeBuilder(
+        curve: map['curve'] ?? Curves.linear,
+        data: ThemeDecoder.decodeThemeData(
+          map['data'],
+          validate: false,
+        ),
+        duration: JsonClass.parseDurationFromMillis(
+              map['duration'],
+            ) ??
+            kThemeAnimationDuration,
+        isMaterialAppTheme: JsonClass.parseBool(
+              map['isMaterialAppTheme'],
+            ) ??
+            false,
+        onEnd: map['onEnd'],
+      );
+    }
+
+    return result;
+  }
+
+  @override
+  Widget buildCustom({
+    ChildWidgetBuilder childBuilder,
+    BuildContext context,
+    JsonWidgetData data,
+    Key key,
+  }) {
+    assert(
+      data.children?.length == 1,
+      '[JsonAnimatedThemeBuilder] only supports exactly one child.',
+    );
+
+    return _JsonAnimatedTheme(
+      builder: this,
+      childBuilder: childBuilder,
+      data: data,
+    );
+  }
+}
+
+class _JsonAnimatedTheme extends StatefulWidget {
+  _JsonAnimatedTheme({
+    @required this.builder,
+    @required this.childBuilder,
+    @required this.data,
+  })  : assert(builder != null),
+        assert(data != null);
+
+  final JsonAnimatedThemeBuilder builder;
+  final ChildWidgetBuilder childBuilder;
+  final JsonWidgetData data;
+
+  @override
+  _JsonAnimatedThemeState createState() => _JsonAnimatedThemeState();
+}
+
+class _JsonAnimatedThemeState extends State<_JsonAnimatedTheme> {
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedTheme(
+      curve: widget.builder.curve,
+      data: widget.builder.data,
+      duration: widget.builder.duration,
+      isMaterialAppTheme: widget.builder.isMaterialAppTheme,
+      onEnd: widget.builder.onEnd,
+      child: widget.data.children[0].build(
+        childBuilder: widget.childBuilder,
+        context: context,
+      ),
+    );
+  }
+}

--- a/lib/src/components/json_widget_registry.dart
+++ b/lib/src/components/json_widget_registry.dart
@@ -122,6 +122,10 @@ class JsonWidgetRegistry {
       builder: JsonAnimatedPositionedDirectionalBuilder.fromDynamic,
       schemaId: AnimatedPositionedDirectionalSchema.id,
     ),
+    JsonAnimatedThemeBuilder.type: JsonWidgetBuilderContainer(
+      builder: JsonAnimatedThemeBuilder.fromDynamic,
+      schemaId: AnimatedThemeSchema.id,
+    ),
     JsonAppBarBuilder.type: JsonWidgetBuilderContainer(
       builder: JsonAppBarBuilder.fromDynamic,
       schemaId: AppBarSchema.id,

--- a/lib/src/schema/all.dart
+++ b/lib/src/schema/all.dart
@@ -6,6 +6,7 @@ export 'schemas/animated_padding_schema.dart';
 export 'schemas/animated_physical_model_schema.dart';
 export 'schemas/animated_positioned_directional_schema.dart';
 export 'schemas/animated_positioned_schema.dart';
+export 'schemas/animated_theme_schema.dart';
 export 'schemas/app_bar_schema.dart';
 export 'schemas/aspect_ratio_schema.dart';
 export 'schemas/asset_image_schema.dart';

--- a/lib/src/schema/schema_validator.dart
+++ b/lib/src/schema/schema_validator.dart
@@ -37,6 +37,10 @@ class SchemaValidator {
         AnimatedPositionedSchema.id,
         AnimatedPositionedSchema.schema,
       );
+      cache.addSchema(
+        AnimatedThemeSchema.id,
+        AnimatedThemeSchema.schema,
+      );
       cache.addSchema(AppBarSchema.id, AppBarSchema.schema);
       cache.addSchema(AspectRatioSchema.id, AspectRatioSchema.schema);
       cache.addSchema(AssetImageSchema.id, AssetImageSchema.schema);

--- a/lib/src/schema/schemas/animated_theme_schema.dart
+++ b/lib/src/schema/schemas/animated_theme_schema.dart
@@ -1,0 +1,24 @@
+import 'package:json_theme/json_theme_schemas.dart';
+
+class AnimatedThemeSchema {
+  static const id =
+      'https://peifferinnovations.com/json_dynamic_widget/schemas/animated_theme';
+
+  static final schema = {
+    r'$schema': 'http://json-schema.org/draft-06/schema#',
+    r'$id': '$id',
+    'type': 'object',
+    'title': 'AnimatedThemeBuilder',
+    'additionalProperties': false,
+    'required': [
+      'data',
+    ],
+    'properties': {
+      'curve': SchemaHelper.stringSchema,
+      'data': SchemaHelper.objectSchema(ThemeDataSchema.id),
+      'duration': SchemaHelper.numberSchema,
+      'isMaterialAppTheme': SchemaHelper.boolSchema,
+      'onEnd': SchemaHelper.stringSchema,
+    },
+  };
+}

--- a/test/builders/json_animated_theme_builder_test.dart
+++ b/test/builders/json_animated_theme_builder_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:json_dynamic_widget/json_dynamic_widget.dart';
+
+void main() {
+  test('type', () {
+    const type = JsonAnimatedThemeBuilder.type;
+
+    expect(type, 'animated_theme');
+    expect(JsonWidgetRegistry.instance.getWidgetBuilder(type) != null, true);
+    expect(
+      JsonWidgetRegistry.instance.getWidgetBuilder(type)(
+        {
+          'data': {},
+        },
+      ) is JsonAnimatedThemeBuilder,
+      true,
+    );
+  });
+}


### PR DESCRIPTION
## This won't merge to main yet

## Description

This PR adds the AnimatedTheme JSON widget support.


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Code Style Guide] and followed the process outlined there for submitting PRs.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I updated `pubspec.yaml`, `build.properties`, and `ios/Podfile` with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [x] I am authorized to release this code under the MIT License and agree to do so


## UI Change

Does your PR affect any UI screens?

- [x] Yes, the relevant screens are included below.

The affected screens are `animated_theme.json` as the new widget example and `main.dart` adding the new example to the list.
