### PR TITLE
Added AnimatedSize widget support

### DIFF
--- a/example/assets/pages/animated_size.json
+++ b/example/assets/pages/animated_size.json
@@ -1,0 +1,60 @@
+{
+  "type": "scaffold",
+  "args": {
+    "appBar": {
+      "type": "app_bar",
+      "args": {
+        "title": {
+          "type": "text",
+          "args": {
+            "text": "AnimatedSize"
+          }
+        }
+      }
+    },
+    "body": {
+      "type": "set_value",
+      "args": {
+        "customText": "This is a short text."
+      },
+      "child": {
+        "type": "center",
+        "child": {
+          "type": "container",
+          "args": {
+            "decoration": {
+              "border": {
+                "color": "#000"
+              }
+            }
+          },
+          "child": {
+            "type": "animated_size",
+            "args": {
+              "duration": 1000,
+              "reverseDuration": 3000
+            },
+            "child": {
+              "type": "text",
+              "args": {
+                "text": "{{customText}}"
+              }
+            }
+          }
+        }
+      }
+    },
+    "floatingActionButton": {
+      "type": "raised_button",
+      "args": {
+        "onPressed": "##set_value(customText, This is not a short text. This is a very very long text.)##"
+      },
+      "child": {
+        "type": "text",
+        "args": {
+          "text": "Press Me!"
+        }
+      }
+    }
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -144,6 +144,7 @@ class RootPage extends StatelessWidget {
     'animated_physical_model',
     'animated_positioned',
     'animated_positioned_directional',
+    'animated_size',
     'animated_theme',
     'aspect_ratio',
     'asset_images',

--- a/lib/json_dynamic_widget.dart
+++ b/lib/json_dynamic_widget.dart
@@ -6,6 +6,7 @@ export 'src/builders/json_animated_padding_builder.dart';
 export 'src/builders/json_animated_physical_model_builder.dart';
 export 'src/builders/json_animated_positioned_builder.dart';
 export 'src/builders/json_animated_positioned_directional_builder.dart';
+export 'src/builders/json_animated_size_builder.dart';
 export 'src/builders/json_animated_theme_builder.dart';
 export 'src/builders/json_app_bar_builder.dart';
 export 'src/builders/json_aspect_ratio_builder.dart';

--- a/lib/src/builders/json_animated_size_builder.dart
+++ b/lib/src/builders/json_animated_size_builder.dart
@@ -1,0 +1,144 @@
+import 'package:child_builder/child_builder.dart';
+import 'package:flutter/material.dart';
+import 'package:json_class/json_class.dart';
+import 'package:json_dynamic_widget/json_dynamic_widget.dart';
+import 'package:json_theme/json_theme.dart';
+
+/// Builder that can build an [AnimatedSize] widget.
+/// See the [fromDynamic] for the format.
+class JsonAnimatedSizeBuilder extends JsonWidgetBuilder {
+  JsonAnimatedSizeBuilder({
+    this.alignment,
+    this.curve,
+    @required this.duration,
+    this.reverseDuration,
+    this.vsync,
+  }) : assert(duration != null);
+
+  static const type = 'animated_size';
+
+  final AlignmentGeometry alignment;
+  final Curve curve;
+  final Duration duration;
+  final Duration reverseDuration;
+  final TickerProvider vsync;
+
+  /// Builds the builder from a Map-like dynamic structure.  This expects the
+  /// JSON format to be of the following structure:
+  ///
+  /// ```json
+  /// {
+  ///   "alignment": <AlignmentGeometry>,
+  ///   "curve": <Curve>,
+  ///   "duration": <int; millis>,
+  ///   "reverseDuration": <int; millis>,
+  ///   "vsync": <TickerProvider>,
+  /// }
+  /// ```
+  ///
+  /// As a note, the [Curve] and [TickerProvider] cannot be decoded via JSON.
+  /// Instead, the only way to bind those values to the builder is to use a
+  /// function or a variable reference via the [JsonWidgetRegistry]. But if
+  /// [vsync] is not passed, the widget itself will be the [TickerProvider].
+  static JsonAnimatedSizeBuilder fromDynamic(
+    dynamic map, {
+    JsonWidgetRegistry registry,
+  }) {
+    JsonAnimatedSizeBuilder result;
+
+    if (map != null) {
+      result = JsonAnimatedSizeBuilder(
+        alignment: ThemeDecoder.decodeAlignment(
+              map['alignment'],
+              validate: false,
+            ) ??
+            Alignment.center,
+        curve: map['curve'] ?? Curves.linear,
+        duration: JsonClass.parseDurationFromMillis(
+          map['duration'],
+        ),
+        reverseDuration: JsonClass.parseDurationFromMillis(
+          map['reverseDuration'],
+        ),
+        vsync: map['vsync'],
+      );
+    }
+
+    return result;
+  }
+
+  @override
+  Widget buildCustom({
+    ChildWidgetBuilder childBuilder,
+    BuildContext context,
+    JsonWidgetData data,
+    Key key,
+  }) {
+    assert(
+      data.children?.length == 1,
+      '[JsonAnimatedSizeBuilder] only supports exactly one child.',
+    );
+
+    return _JsonAnimatedSize(
+      builder: this,
+      childBuilder: childBuilder,
+      data: data,
+    );
+  }
+}
+
+class _JsonAnimatedSize extends StatefulWidget {
+  _JsonAnimatedSize({
+    @required this.builder,
+    @required this.childBuilder,
+    @required this.data,
+  })  : assert(builder != null),
+        assert(data != null);
+
+  final JsonAnimatedSizeBuilder builder;
+  final ChildWidgetBuilder childBuilder;
+  final JsonWidgetData data;
+
+  @override
+  State<_JsonAnimatedSize> createState() {
+    State result = builder.vsync != null
+        ? _JsonAnimatedSizeState()
+        : _JsonAnimatedSizeStateTicker();
+    return result;
+  }
+}
+
+class _JsonAnimatedSizeState extends State<_JsonAnimatedSize> {
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSize(
+      alignment: widget.builder.alignment,
+      curve: widget.builder.curve,
+      duration: widget.builder.duration,
+      reverseDuration: widget.builder.reverseDuration,
+      vsync: widget.builder.vsync,
+      child: widget.data.children[0].build(
+        childBuilder: widget.childBuilder,
+        context: context,
+      ),
+    );
+  }
+}
+
+class _JsonAnimatedSizeStateTicker extends State<_JsonAnimatedSize>
+    with SingleTickerProviderStateMixin {
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSize(
+      alignment: widget.builder.alignment,
+      curve: widget.builder.curve,
+      duration: widget.builder.duration,
+      reverseDuration: widget.builder.reverseDuration,
+      vsync: this,
+      child: widget.data.children[0].build(
+        childBuilder: widget.childBuilder,
+        context: context,
+      ),
+    );
+  }
+}

--- a/lib/src/components/json_widget_registry.dart
+++ b/lib/src/components/json_widget_registry.dart
@@ -122,6 +122,10 @@ class JsonWidgetRegistry {
       builder: JsonAnimatedPositionedDirectionalBuilder.fromDynamic,
       schemaId: AnimatedPositionedDirectionalSchema.id,
     ),
+    JsonAnimatedSizeBuilder.type: JsonWidgetBuilderContainer(
+      builder: JsonAnimatedSizeBuilder.fromDynamic,
+      schemaId: AnimatedSizeSchema.id,
+    ),
     JsonAnimatedThemeBuilder.type: JsonWidgetBuilderContainer(
       builder: JsonAnimatedThemeBuilder.fromDynamic,
       schemaId: AnimatedThemeSchema.id,

--- a/lib/src/schema/all.dart
+++ b/lib/src/schema/all.dart
@@ -6,6 +6,7 @@ export 'schemas/animated_padding_schema.dart';
 export 'schemas/animated_physical_model_schema.dart';
 export 'schemas/animated_positioned_directional_schema.dart';
 export 'schemas/animated_positioned_schema.dart';
+export 'schemas/animated_size_schema.dart';
 export 'schemas/animated_theme_schema.dart';
 export 'schemas/app_bar_schema.dart';
 export 'schemas/aspect_ratio_schema.dart';

--- a/lib/src/schema/schema_validator.dart
+++ b/lib/src/schema/schema_validator.dart
@@ -38,6 +38,10 @@ class SchemaValidator {
         AnimatedPositionedSchema.schema,
       );
       cache.addSchema(
+        AnimatedSizeSchema.id,
+        AnimatedSizeSchema.schema,
+      );
+      cache.addSchema(
         AnimatedThemeSchema.id,
         AnimatedThemeSchema.schema,
       );

--- a/lib/src/schema/schemas/animated_size_schema.dart
+++ b/lib/src/schema/schemas/animated_size_schema.dart
@@ -1,0 +1,24 @@
+import 'package:json_theme/json_theme_schemas.dart';
+
+class AnimatedSizeSchema {
+  static const id =
+      'https://peifferinnovations.com/json_dynamic_widget/schemas/animated_size';
+
+  static final schema = {
+    r'$schema': 'http://json-schema.org/draft-06/schema#',
+    r'$id': '$id',
+    'type': 'object',
+    'title': 'AnimatedSizeBuilder',
+    'additionalProperties': false,
+    'required': [
+      'duration',
+    ],
+    'properties': {
+      'alignment': SchemaHelper.objectSchema(AlignmentSchema.id),
+      'curve': SchemaHelper.stringSchema,
+      'duration': SchemaHelper.numberSchema,
+      'reverseDuration': SchemaHelper.numberSchema,
+      'vsync': SchemaHelper.stringSchema,
+    },
+  };
+}

--- a/test/builders/json_animated_size_builder_test.dart
+++ b/test/builders/json_animated_size_builder_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:json_dynamic_widget/json_dynamic_widget.dart';
+
+void main() {
+  test('type', () {
+    const type = JsonAnimatedSizeBuilder.type;
+
+    expect(type, 'animated_size');
+    expect(JsonWidgetRegistry.instance.getWidgetBuilder(type) != null, true);
+    expect(
+      JsonWidgetRegistry.instance.getWidgetBuilder(type)(
+        {
+          'duration': 1000,
+        },
+      ) is JsonAnimatedSizeBuilder,
+      true,
+    );
+  });
+}


### PR DESCRIPTION
## This won't merge to main yet

## Description

This PR adds the AnimatedSize JSON widget support.


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Code Style Guide] and followed the process outlined there for submitting PRs.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I updated `pubspec.yaml`, `build.properties`, and `ios/Podfile` with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [x] I am authorized to release this code under the MIT License and agree to do so


## UI Change

Does your PR affect any UI screens?

- [x] Yes, the relevant screens are included below.

The affected screens are `animated_size.json` as the new widget example and `main.dart` adding the new example to the list.
