### PR TITLE
Added TweenAnimationBuilder widget support 

### DIFF
--- a/example/assets/pages/tween_animation.json
+++ b/example/assets/pages/tween_animation.json
@@ -1,0 +1,43 @@
+{
+  "type": "scaffold",
+  "args": {
+    "appBar": {
+      "type": "app_bar",
+      "args": {
+        "title": {
+          "type": "text",
+          "args": {
+            "text": "TweenAnimation"
+          }
+        }
+      }
+    },
+    "body": {
+      "type": "set_value",
+      "args": {
+        "customSize": 50.0
+      },
+      "child": {
+        "type": "center",
+        "child": {
+          "type": "tween_animation",
+          "args": {
+            "builder": "##getCustomTweenBuilder()##",
+            "duration": 1000,
+            "tween": "##getCustomTween({{customSize}})##"
+          },
+          "child": {
+            "type": "icon",
+            "args": {
+              "color": "#0000FF",
+              "icon": {
+                "codePoint": "0xe5db",
+                "fontFamily": "MaterialIcons"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -102,6 +102,21 @@ void main() async {
             ),
           );
         },
+    'getCustomTweenBuilder': ({args, registry}) =>
+        (BuildContext context, dynamic size, Widget child) {
+          return IconButton(
+            icon: child,
+            iconSize: size,
+            onPressed: () {
+              var _current = registry.getValue('customSize');
+              var _size = _current == 50.0 ? 100.0 : 50.0;
+              registry.setValue('customSize', _size);
+            },
+          );
+        },
+    'getCustomTween': ({args, registry}) {
+      return Tween<double>(begin: 0, end: args[0]);
+    }
   });
 
   registry.setValue('customRect', Rect.largest);
@@ -174,6 +189,7 @@ class RootPage extends StatelessWidget {
     'simple_page',
     'switch',
     'theme',
+    'tween_animation',
   ];
 
   Future<void> _onPageSelected(BuildContext context, String themeId) async {

--- a/lib/json_dynamic_widget.dart
+++ b/lib/json_dynamic_widget.dart
@@ -63,6 +63,7 @@ export 'src/builders/json_switch_builder.dart';
 export 'src/builders/json_text_builder.dart';
 export 'src/builders/json_text_form_field_builder.dart';
 export 'src/builders/json_theme_builder.dart';
+export 'src/builders/json_tween_animation_builder.dart';
 export 'src/builders/json_widget_builder.dart';
 
 export 'src/components/json_widget_regex_helper.dart';

--- a/lib/src/builders/json_tween_animation_builder.dart
+++ b/lib/src/builders/json_tween_animation_builder.dart
@@ -1,0 +1,118 @@
+import 'package:child_builder/child_builder.dart';
+import 'package:flutter/material.dart';
+import 'package:json_class/json_class.dart';
+import 'package:json_dynamic_widget/json_dynamic_widget.dart';
+
+/// Builder that can build an [TweenAnimationBuilder] widget.
+/// See the [fromDynamic] for the format.
+class JsonTweenAnimationBuilder extends JsonWidgetBuilder {
+  JsonTweenAnimationBuilder({
+    @required this.builder,
+    this.curve,
+    @required this.duration,
+    this.onEnd,
+    @required this.tween,
+  })  : assert(builder != null),
+        assert(duration != null),
+        assert(tween != null);
+
+  static const type = 'tween_animation';
+
+  final ValueWidgetBuilder builder;
+  final Curve curve;
+  final Duration duration;
+  final VoidCallback onEnd;
+  final Tween tween;
+
+  /// Builds the builder from a Map-like dynamic structure.  This expects the
+  /// JSON format to be of the following structure:
+  ///
+  /// ```json
+  /// {
+  ///   "builder": <ValueWidgetBuilder>,
+  ///   "curve": <Curve>,
+  ///   "duration": <int; millis>,
+  ///   "onEnd": <VoidCallback>,
+  ///   "tween": <Tween>
+  /// }
+  /// ```
+  ///
+  /// As a note, the [ValueWidgetBuilder], [Curve], [VoidCallback] cannot be decoded via JSON.
+  /// Instead, the only way to bind those values to the builder is to use a
+  /// function or a variable reference via the [JsonWidgetRegistry]. The [Tween] can only be
+  /// bound through a function reference.
+  static JsonTweenAnimationBuilder fromDynamic(
+    dynamic map, {
+    JsonWidgetRegistry registry,
+  }) {
+    JsonTweenAnimationBuilder result;
+
+    if (map != null) {
+      result = JsonTweenAnimationBuilder(
+        builder: map['builder'],
+        curve: map['curve'] ?? Curves.linear,
+        duration: JsonClass.parseDurationFromMillis(
+          map['duration'],
+        ),
+        onEnd: map['onEnd'],
+        tween: map['tween'],
+      );
+    }
+
+    return result;
+  }
+
+  @override
+  Widget buildCustom({
+    ChildWidgetBuilder childBuilder,
+    BuildContext context,
+    JsonWidgetData data,
+    Key key,
+  }) {
+    assert(
+      data.children?.length == 1 || data.children?.isNotEmpty != true,
+      '[JsonTweenAnimationBuilder] only supports zero or one child.',
+    );
+
+    return _JsonTweenAnimation(
+      builder: this,
+      childBuilder: childBuilder,
+      data: data,
+    );
+  }
+}
+
+class _JsonTweenAnimation extends StatefulWidget {
+  _JsonTweenAnimation({
+    @required this.builder,
+    @required this.childBuilder,
+    @required this.data,
+  })  : assert(builder != null),
+        assert(data != null);
+
+  final JsonTweenAnimationBuilder builder;
+  final ChildWidgetBuilder childBuilder;
+  final JsonWidgetData data;
+
+  @override
+  _JsonTweenAnimationState createState() => _JsonTweenAnimationState();
+}
+
+class _JsonTweenAnimationState extends State<_JsonTweenAnimation> {
+  @override
+  Widget build(BuildContext context) {
+    return TweenAnimationBuilder(
+      builder: widget.builder.builder,
+      curve: widget.builder.curve,
+      duration: widget.builder.duration,
+      onEnd: widget.builder.onEnd,
+      tween: widget.builder.tween,
+      child: widget.data.children?.length != 1
+          ? null
+          : widget.data.children[0].build(
+              childBuilder: widget.childBuilder,
+              context: context,
+            ),
+    );
+  }
+}

--- a/lib/src/components/json_widget_registry.dart
+++ b/lib/src/components/json_widget_registry.dart
@@ -346,6 +346,10 @@ class JsonWidgetRegistry {
       builder: JsonTextFormFieldBuilder.fromDynamic,
       schemaId: TextFormFieldSchema.id,
     ),
+    JsonTweenAnimationBuilder.type: JsonWidgetBuilderContainer(
+      builder: JsonTweenAnimationBuilder.fromDynamic,
+      schemaId: TweenAnimationSchema.id,
+    ),
     JsonThemeBuilder.type: JsonWidgetBuilderContainer(
       builder: JsonThemeBuilder.fromDynamic,
       schemaId: ThemeSchema.id,

--- a/lib/src/schema/all.dart
+++ b/lib/src/schema/all.dart
@@ -64,3 +64,4 @@ export 'schemas/switch_schema.dart';
 export 'schemas/text_form_field_schema.dart';
 export 'schemas/text_schema.dart';
 export 'schemas/theme_schema.dart';
+export 'schemas/tween_animation_schema.dart';

--- a/lib/src/schema/schema_validator.dart
+++ b/lib/src/schema/schema_validator.dart
@@ -113,6 +113,7 @@ class SchemaValidator {
       cache.addSchema(TextFormFieldSchema.id, TextFormFieldSchema.schema);
       cache.addSchema(TextSchema.id, TextSchema.schema);
       cache.addSchema(ThemeSchema.id, ThemeSchema.schema);
+      cache.addSchema(TweenAnimationSchema.id, TweenAnimationSchema.schema);
 
       return true;
     }());

--- a/lib/src/schema/schemas/tween_animation_schema.dart
+++ b/lib/src/schema/schemas/tween_animation_schema.dart
@@ -1,0 +1,26 @@
+import 'package:json_theme/json_theme_schemas.dart';
+
+class TweenAnimationSchema {
+  static const id =
+      'https://peifferinnovations.com/json_dynamic_widget/schemas/tween_animation';
+
+  static final schema = {
+    r'$schema': 'http://json-schema.org/draft-06/schema#',
+    r'$id': '$id',
+    'type': 'object',
+    'title': 'TweenAnimationBuilder',
+    'additionalProperties': false,
+    'required': [
+      'builder',
+      'duration',
+      'tween',
+    ],
+    'properties': {
+      'builder': SchemaHelper.stringSchema,
+      'curve': SchemaHelper.stringSchema,
+      'duration': SchemaHelper.numberSchema,
+      'onEnd': SchemaHelper.stringSchema,
+      'tween': SchemaHelper.stringSchema,
+    },
+  };
+}

--- a/test/builders/json_tween_animation_builder_test.dart
+++ b/test/builders/json_tween_animation_builder_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/animation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:json_dynamic_widget/json_dynamic_widget.dart';
+
+void main() {
+  test('type', () {
+    const type = JsonTweenAnimationBuilder.type;
+
+    expect(type, 'tween_animation');
+    expect(JsonWidgetRegistry.instance.getWidgetBuilder(type) != null, true);
+    expect(
+      JsonWidgetRegistry.instance.getWidgetBuilder(type)(
+        {
+          'builder': (context, val, child) {},
+          'duration': 1000,
+          'tween': Tween(begin: 0, end: 0),
+        },
+      ) is JsonTweenAnimationBuilder,
+      true,
+    );
+  });
+}


### PR DESCRIPTION
## This won't merge to main yet

## Description

This PR adds the TweenAnimationBuilder JSON widget support.


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Code Style Guide] and followed the process outlined there for submitting PRs.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I updated `pubspec.yaml`, `build.properties`, and `ios/Podfile` with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [x] I am authorized to release this code under the MIT License and agree to do so


## UI Change

Does your PR affect any UI screens?

- [x] Yes, the relevant screens are included below.

The affected screens are `tween_animation.json` as the new widget example and `main.dart` adding the new example to the list.
